### PR TITLE
Avoid html-writing deps in the main package

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -14,3 +14,5 @@
 (define pkg-authors '(mflatt))
 
 (define scribblings '(("plt-service-monitor.scrbl")))
+
+(define compile-omit-paths '("site"))


### PR DESCRIPTION
After #3, `html-writing` accidentally becomes a deps of the main `plt-service-monitor`, causing a failure in pkg-build. This PR omits compilation on the subdirectory, avoiding the failure.